### PR TITLE
fix: also reset self.prompt_height in `TermThemeRenderer::clear`.

### DIFF
--- a/src/theme.rs
+++ b/src/theme.rs
@@ -843,6 +843,7 @@ impl<'a> TermThemeRenderer<'a> {
         self.term
             .clear_last_lines(self.height + self.prompt_height)?;
         self.height = 0;
+        self.prompt_height = 0;
         Ok(())
     }
 


### PR DESCRIPTION
This appears like an oversight: we clear the last `self.height+self.prompt_height` lines from the output; we set `height` to 0, but not `prompt_height`. We should also reset prompt_height.

This can cause issues if we were to call clear() twice in a row: we would clear prompt_height lines more than we should.