### PR TITLE
Provide a basic default implementation of `History`

### DIFF
--- a/examples/history.rs
+++ b/examples/history.rs
@@ -1,12 +1,13 @@
-use dialoguer::{theme::ColorfulTheme, Input};
-use std::{collections::VecDeque, process};
+use dialoguer::{theme::ColorfulTheme, BasicHistory, Input};
+use std::process;
 
 fn main() {
     println!("Use 'exit' to quit the prompt");
+    println!("In this example, history is limited to 8 entries and contains no duplicates");
     println!("Use the Up/Down arrows to scroll through history");
     println!();
 
-    let mut history = VecDeque::new();
+    let mut history = BasicHistory::new().max_entries(8).no_duplicates(true);
 
     loop {
         if let Ok(cmd) = Input::<String>::with_theme(&ColorfulTheme::default())

--- a/examples/history.rs
+++ b/examples/history.rs
@@ -9,6 +9,10 @@ fn main() {
 
     let mut history = MyHistory::default();
 
+    /// We can also use `Vec` or `VecDeque` directly for a simple infinite history.
+    // let mut history = Vec::new();
+    // let mut history = VecDeque::new();
+
     loop {
         if let Ok(cmd) = Input::<String>::with_theme(&ColorfulTheme::default())
             .with_prompt("dialoguer")

--- a/examples/history.rs
+++ b/examples/history.rs
@@ -1,17 +1,12 @@
-use dialoguer::{theme::ColorfulTheme, History, Input};
+use dialoguer::{theme::ColorfulTheme, Input};
 use std::{collections::VecDeque, process};
 
 fn main() {
     println!("Use 'exit' to quit the prompt");
-    println!("In this example, history is limited to 4 entries");
     println!("Use the Up/Down arrows to scroll through history");
     println!();
 
-    let mut history = MyHistory::default();
-
-    /// We can also use `Vec` or `VecDeque` directly for a simple infinite history.
-    // let mut history = Vec::new();
-    // let mut history = VecDeque::new();
+    let mut history = VecDeque::new();
 
     loop {
         if let Ok(cmd) = Input::<String>::with_theme(&ColorfulTheme::default())
@@ -24,32 +19,5 @@ fn main() {
             }
             println!("Entered {}", cmd);
         }
-    }
-}
-
-struct MyHistory {
-    max: usize,
-    history: VecDeque<String>,
-}
-
-impl Default for MyHistory {
-    fn default() -> Self {
-        MyHistory {
-            max: 4,
-            history: VecDeque::new(),
-        }
-    }
-}
-
-impl<T: ToString> History<T> for MyHistory {
-    fn read(&self, pos: usize) -> Option<String> {
-        self.history.get(pos).cloned()
-    }
-
-    fn write(&mut self, val: &T) {
-        if self.history.len() == self.max {
-            self.history.pop_back();
-        }
-        self.history.push_front(val.to_string());
     }
 }

--- a/examples/history_custom.rs
+++ b/examples/history_custom.rs
@@ -1,0 +1,51 @@
+use dialoguer::{theme::ColorfulTheme, History, Input};
+use std::{collections::VecDeque, process};
+
+fn main() {
+    println!("Use 'exit' to quit the prompt");
+    println!("In this example, history is limited to 4 entries");
+    println!("Use the Up/Down arrows to scroll through history");
+    println!();
+
+    let mut history = MyHistory::default();
+
+    loop {
+        if let Ok(cmd) = Input::<String>::with_theme(&ColorfulTheme::default())
+            .with_prompt("dialoguer")
+            .history_with(&mut history)
+            .interact_text()
+        {
+            if cmd == "exit" {
+                process::exit(0);
+            }
+            println!("Entered {}", cmd);
+        }
+    }
+}
+
+struct MyHistory {
+    max: usize,
+    history: VecDeque<String>,
+}
+
+impl Default for MyHistory {
+    fn default() -> Self {
+        MyHistory {
+            max: 4,
+            history: VecDeque::new(),
+        }
+    }
+}
+
+impl<T: ToString> History<T> for MyHistory {
+    fn read(&self, pos: usize) -> Option<String> {
+        self.history.get(pos).cloned()
+    }
+
+    fn write(&mut self, val: &T) {
+        if self.history.len() == self.max {
+            self.history.pop_back();
+        }
+        self.history.push_front(val.to_string());
+    }
+}

--- a/src/history.rs
+++ b/src/history.rs
@@ -16,6 +16,7 @@ pub trait History<T> {
     fn write(&mut self, val: &T);
 }
 
+
 impl<T: ToString> History<T> for VecDeque<String> {
     fn read(&self, pos: usize) -> Option<String> {
         self.get(pos).cloned()

--- a/src/history.rs
+++ b/src/history.rs
@@ -16,13 +16,63 @@ pub trait History<T> {
     fn write(&mut self, val: &T);
 }
 
+pub struct BasicHistory {
+    max_entries: Option<usize>,
+    deque: VecDeque<String>,
+    no_duplicates: bool,
+}
 
-impl<T: ToString> History<T> for VecDeque<String> {
+impl BasicHistory {
+    /// Creates a new basic history value which has no limit on the number of
+    /// entries and allows for duplicates.
+    pub fn new() -> Self {
+        Self {
+            max_entries: None,
+            deque: VecDeque::new(),
+            no_duplicates: false,
+        }
+    }
+
+    /// Limit the number of entries stored in the history.
+    pub fn max_entries(self, max_entries: usize) -> Self {
+        Self {
+            max_entries: Some(max_entries),
+            ..self
+        }
+    }
+
+    /// Prevent duplicates in the history. This means that any previous entries
+    /// that are equal to a new entry are removed before the new entry is added.
+    pub fn no_duplicates(self, no_duplicates: bool) -> Self {
+        Self {
+            no_duplicates,
+            ..self
+        }
+    }
+}
+
+impl<T: ToString> History<T> for BasicHistory {
     fn read(&self, pos: usize) -> Option<String> {
-        self.get(pos).cloned()
+        self.deque.get(pos).cloned()
     }
 
     fn write(&mut self, val: &T) {
-        self.push_front(val.to_string())
+        let val = val.to_string();
+
+        if self.no_duplicates {
+            self.deque.retain(|v| v != &val);
+        }
+
+        self.deque.push_front(val);
+
+        if let Some(max_entries) = self.max_entries {
+            self.deque.truncate(max_entries);
+        }
+    }
+}
+
+impl Default for BasicHistory {
+    fn default() -> Self {
+        Self::new()
     }
 }

--- a/src/history.rs
+++ b/src/history.rs
@@ -1,3 +1,5 @@
+use std::collections::VecDeque;
+
 /// Trait for history handling.
 pub trait History<T> {
     /// This is called with the current position that should
@@ -12,4 +14,34 @@ pub trait History<T> {
     /// in history at the first location. Normally history
     /// is implemented as a FIFO queue.
     fn write(&mut self, val: &T);
+}
+
+impl History<String> for Vec<String> {
+    fn read(&self, pos: usize) -> Option<String> {
+        // We have to check manually here instead of using `Vec::get` since
+        // subtracting from `usize` into the negative throws an exception.
+        if pos >= self.len() {
+            None
+        } else {
+            // Since we have already ensured that `pos`
+            // is in bounds, we can use direct access.
+            Some(self[self.len() - pos - 1].clone())
+        }
+    }
+
+    fn write(&mut self, val: &String) {
+        self.push(val.clone())
+    }
+}
+
+impl History<String> for VecDeque<String> {
+    fn read(&self, pos: usize) -> Option<String> {
+        self.get(pos).cloned()
+    }
+
+    fn write(&mut self, val: &String) {
+        // With `VecDeque` we can simply use `push_front`,
+        // allowing for normal forward indexing in `read`.
+        self.push_front(val.clone())
+    }
 }

--- a/src/history.rs
+++ b/src/history.rs
@@ -16,32 +16,12 @@ pub trait History<T> {
     fn write(&mut self, val: &T);
 }
 
-impl History<String> for Vec<String> {
-    fn read(&self, pos: usize) -> Option<String> {
-        // We have to check manually here instead of using `Vec::get` since
-        // subtracting from `usize` into the negative throws an exception.
-        if pos >= self.len() {
-            None
-        } else {
-            // Since we have already ensured that `pos`
-            // is in bounds, we can use direct access.
-            Some(self[self.len() - pos - 1].clone())
-        }
-    }
-
-    fn write(&mut self, val: &String) {
-        self.push(val.clone())
-    }
-}
-
-impl History<String> for VecDeque<String> {
+impl<T: ToString> History<T> for VecDeque<String> {
     fn read(&self, pos: usize) -> Option<String> {
         self.get(pos).cloned()
     }
 
-    fn write(&mut self, val: &String) {
-        // With `VecDeque` we can simply use `push_front`,
-        // allowing for normal forward indexing in `read`.
-        self.push_front(val.clone())
+    fn write(&mut self, val: &T) {
+        self.push_front(val.to_string())
     }
 }

--- a/src/history.rs
+++ b/src/history.rs
@@ -25,6 +25,14 @@ pub struct BasicHistory {
 impl BasicHistory {
     /// Creates a new basic history value which has no limit on the number of
     /// entries and allows for duplicates.
+    /// 
+    /// # Example
+    /// 
+    /// A history with at most 8 entries and no duplicates:
+    /// 
+    /// ```rs
+    /// let mut history = BasicHistory::new().max_entries(8).no_duplicates(true);
+    /// ```
     pub fn new() -> Self {
         Self {
             max_entries: None,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,7 +37,7 @@ pub use console;
 #[cfg(feature = "editor")]
 pub use edit::Editor;
 #[cfg(feature = "history")]
-pub use history::History;
+pub use history::{History, BasicHistory};
 use paging::Paging;
 pub use prompts::{
     confirm::Confirm, input::Input, multi_select::MultiSelect, select::Select, sort::Sort,

--- a/src/prompts/input.rs
+++ b/src/prompts/input.rs
@@ -13,6 +13,28 @@ use console::{Key, Term};
 
 type ValidatorCallback<'a, T> = Box<dyn FnMut(&T) -> Option<String> + 'a>;
 
+#[cfg(feature = "history")]
+enum HistoryBox<'a, T> {
+    Borrowed(&'a mut dyn History<T>),
+    Owned(Box<dyn History<T>>),
+}
+
+impl<'a, T> History<T> for HistoryBox<'a, T> {
+    fn read(&self, pos: usize) -> Option<String> {
+        match self {
+            HistoryBox::Borrowed(h) => h.read(pos),
+            HistoryBox::Owned(h) => h.read(pos),
+        }
+    }
+
+    fn write(&mut self, val: &T) {
+        match self {
+            HistoryBox::Borrowed(h) => h.write(val),
+            HistoryBox::Owned(h) => h.write(val),
+        }
+    }
+}
+
 /// Renders an input prompt.
 ///
 /// ## Example usage
@@ -50,7 +72,8 @@ pub struct Input<'a, T> {
     permit_empty: bool,
     validator: Option<ValidatorCallback<'a, T>>,
     #[cfg(feature = "history")]
-    history: Option<&'a mut dyn History<T>>,
+    history: Option<HistoryBox<'a, T>>,
+    // history: Option<&'a mut dyn History<T>>,
     #[cfg(feature = "completion")]
     completion: Option<&'a dyn Completion>,
 }
@@ -192,7 +215,25 @@ impl<'a, T> Input<'a, T> {
     where
         H: History<T>,
     {
-        self.history = Some(history);
+        self.history = Some(HistoryBox::Borrowed(history));
+        self
+    }
+
+    #[cfg(feature = "history")]
+    pub fn history_from<H: History<T> + 'static>(&mut self, history: H) -> &mut Self {
+        self.history = Some(HistoryBox::Owned(Box::new(history)));
+        self
+    }
+
+    #[cfg(feature = "history")]
+    pub fn history_infinite(&mut self) -> &mut Self
+    where
+        T: ToString,
+    {
+        use std::collections::VecDeque;
+
+        let history = VecDeque::new();
+        self.history = Some(HistoryBox::Owned(Box::new(history)));
         self
     }
 


### PR DESCRIPTION
As it stands, if one wants to have an input with history, one has to define a custom struct and implement the History trait for it, which is quite some boilerplate code (See [examples/history.rs](https://github.com/mitsuhiko/dialoguer/blob/master/examples/history.rs)). Since in most simple applications, one probably doesn't need any custom history logic (limited size / no duplicates / etc.), simply providing a default implementation for `Vec` and `VecDeque` seems sensible to me.

The `VecDeque` implementation is very straightforward and equivalent to the provided example, except without limiting the size. For the `Vec` implementation we have to index from the back, which requires checking in advance that the `pos` is in bounds, since otherwise we end up subtracting a `usize` below zero, which explodes.