### PR TITLE
Add `validate_with` function to password prompt

### DIFF
--- a/examples/password.rs
+++ b/examples/password.rs
@@ -4,7 +4,7 @@ fn main() {
     let password = Password::with_theme(&ColorfulTheme::default())
         .with_prompt("Password")
         .with_confirmation("Repeat password", "Error: the passwords don't match.")
-        .validate_with(|input: &str| -> Result<(), &str> {
+        .validate_with(|input: &String| -> Result<(), &str> {
             if input.len() > 3 {
                 Ok(())
             } else {

--- a/examples/password.rs
+++ b/examples/password.rs
@@ -4,6 +4,13 @@ fn main() {
     let password = Password::with_theme(&ColorfulTheme::default())
         .with_prompt("Password")
         .with_confirmation("Repeat password", "Error: the passwords don't match.")
+        .validate_with(|input: &String| -> Result<(), &str> {
+            if input.len() > 3 {
+                Ok(())
+            } else {
+                Err("Password must be longer than 3")
+            }
+        })
         .interact()
         .unwrap();
 

--- a/examples/password.rs
+++ b/examples/password.rs
@@ -4,7 +4,7 @@ fn main() {
     let password = Password::with_theme(&ColorfulTheme::default())
         .with_prompt("Password")
         .with_confirmation("Repeat password", "Error: the passwords don't match.")
-        .validate_with(|input: &String| -> Result<(), &str> {
+        .validate_with(|input: &str| -> Result<(), &str> {
             if input.len() > 3 {
                 Ok(())
             } else {

--- a/src/prompts/password.rs
+++ b/src/prompts/password.rs
@@ -8,7 +8,7 @@ use crate::{
 use console::Term;
 use zeroize::Zeroizing;
 
-type PasswordValidatorCallback<'a> = Box<dyn Fn(&str) -> Option<String> + 'a>;
+type PasswordValidatorCallback<'a> = Box<dyn Fn(&String) -> Option<String> + 'a>;
 
 /// Renders a password input prompt.
 ///
@@ -87,7 +87,7 @@ impl<'a> Password<'a> {
     /// # use dialoguer::Password;
     /// let password: String = Password::new()
     ///     .with_prompt("Enter password")
-    ///     .validate_with(|input: &str| -> Result<(), &str> {
+    ///     .validate_with(|input: &String| -> Result<(), &str> {
     ///         if input.len() > 8 {
     ///             Ok(())
     ///         } else {
@@ -104,7 +104,7 @@ impl<'a> Password<'a> {
     {
         let old_validator_func = self.validator.take();
 
-        self.validator = Some(Box::new(move |value: &str| -> Option<String> {
+        self.validator = Some(Box::new(move |value: &String| -> Option<String> {
             if let Some(old) = &old_validator_func {
                 if let Some(err) = old(value) {
                     return Some(err);

--- a/src/prompts/password.rs
+++ b/src/prompts/password.rs
@@ -8,6 +8,8 @@ use crate::{
 use console::Term;
 use zeroize::Zeroizing;
 
+type PasswordValidatorCallback<'a> = Box<dyn FnMut(&String) -> Option<String> + 'a>;
+
 /// Renders a password input prompt.
 ///
 /// ## Example usage
@@ -28,7 +30,7 @@ pub struct Password<'a> {
     theme: &'a dyn Theme,
     allow_empty_password: bool,
     confirmation_prompt: Option<(String, String)>,
-    validator: Option<Box<dyn FnMut(&String) -> Option<String> + 'a>>,
+    validator: Option<PasswordValidatorCallback<'a>>,
 }
 
 impl Default for Password<'static> {

--- a/src/prompts/password.rs
+++ b/src/prompts/password.rs
@@ -82,7 +82,7 @@ impl<'a> Password<'a> {
     /// # Example
     ///
     /// ```no_run
-    /// # use dialoguer::Input;
+    /// # use dialoguer::Password;
     /// let password: String = Password::new()
     ///     .with_prompt("Enter password")
     ///     .validate_with(|input: &String| -> Result<(), &str> {

--- a/src/validate.rs
+++ b/src/validate.rs
@@ -26,6 +26,7 @@ where
 }
 
 /// Trait for password validators.
+#[allow(clippy::ptr_arg)]
 pub trait PasswordValidator {
     type Err;
 
@@ -33,16 +34,16 @@ pub trait PasswordValidator {
     ///
     /// If this produces `Ok(())` then the value is used and parsed, if
     /// an error is returned validation fails with that error.
-    fn validate(&self, input: &str) -> Result<(), Self::Err>;
+    fn validate(&self, input: &String) -> Result<(), Self::Err>;
 }
 
 impl<F, E> PasswordValidator for F
 where
-    F: Fn(&str) -> Result<(), E>,
+    F: Fn(&String) -> Result<(), E>,
 {
     type Err = E;
 
-    fn validate(&self, input: &str) -> Result<(), Self::Err> {
+    fn validate(&self, input: &String) -> Result<(), Self::Err> {
         self(input)
     }
 }

--- a/src/validate.rs
+++ b/src/validate.rs
@@ -24,3 +24,25 @@ where
         self(input)
     }
 }
+
+/// Trait for password validators.
+pub trait PasswordValidator {
+    type Err;
+
+    /// Invoked with the value to validate.
+    ///
+    /// If this produces `Ok(())` then the value is used and parsed, if
+    /// an error is returned validation fails with that error.
+    fn validate(&self, input: &str) -> Result<(), Self::Err>;
+}
+
+impl<F, E> PasswordValidator for F
+where
+    F: Fn(&str) -> Result<(), E>,
+{
+    type Err = E;
+
+    fn validate(&self, input: &str) -> Result<(), Self::Err> {
+        self(input)
+    }
+}


### PR DESCRIPTION
Closes #150 

Implement validation function in `Password` which would be useful for checking the strength of passwords. This PR includes:

- Adding `validator` property and `validate_with` method to `Password`
- Refactoring the password confirmation process in order to reduce complexity
- Adding validation process in `interact_on` method
- Minor update on an example code
