### PR TITLE
Rewrite several prompts to take `IntoIterator<Item: ToString>` instead of `&[T]`

### DIFF
--- a/src/prompts/fuzzy_select.rs
+++ b/src/prompts/fuzzy_select.rs
@@ -81,8 +81,8 @@ impl FuzzySelect<'_> {
     /// Adds multiple items to the fuzzy selector.
     pub fn items<T>(&mut self, items: T) -> &mut Self
     where
-        T::Item: ToString,
         T: IntoIterator,
+        T::Item: ToString,
     {
         for item in items {
             self.items.push(item.to_string());

--- a/src/prompts/fuzzy_select.rs
+++ b/src/prompts/fuzzy_select.rs
@@ -81,8 +81,8 @@ impl FuzzySelect<'_> {
     /// Adds multiple items to the fuzzy selector.
     pub fn items<T>(&mut self, items: T) -> &mut Self
     where
+        T::Item: ToString,
         T: IntoIterator,
-        T::Item: std::string::ToString,
     {
         for item in items {
             self.items.push(item.to_string());

--- a/src/prompts/fuzzy_select.rs
+++ b/src/prompts/fuzzy_select.rs
@@ -79,7 +79,11 @@ impl FuzzySelect<'_> {
     }
 
     /// Adds multiple items to the fuzzy selector.
-    pub fn items<T: ToString>(&mut self, items: &[T]) -> &mut Self {
+    pub fn items<T>(&mut self, items: T) -> &mut Self
+    where
+        T: IntoIterator,
+        T::Item: std::string::ToString,
+    {
         for item in items {
             self.items.push(item.to_string());
         }

--- a/src/prompts/multi_select.rs
+++ b/src/prompts/multi_select.rs
@@ -93,8 +93,8 @@ impl MultiSelect<'_> {
     /// Adds multiple items to the selector.
     pub fn items<T>(&mut self, items: T) -> &mut Self
     where
-        T::Item: ToString,
         T: IntoIterator,
+        T::Item: ToString,
     {
         for item in items {
             self.items.push(item.to_string());
@@ -106,8 +106,8 @@ impl MultiSelect<'_> {
     /// Adds multiple items to the selector with checked state
     pub fn items_checked<T, I>(&mut self, items: T) -> &mut Self
     where
-        I: ToString,
         T: IntoIterator<Item = (I, bool)>,
+        I: ToString,
     {
         for (item, checked) in items {
             self.items.push(item.to_string());

--- a/src/prompts/multi_select.rs
+++ b/src/prompts/multi_select.rs
@@ -91,7 +91,11 @@ impl MultiSelect<'_> {
     }
 
     /// Adds multiple items to the selector.
-    pub fn items<T: ToString>(&mut self, items: &[T]) -> &mut Self {
+    pub fn items<T>(&mut self, items: T) -> &mut Self
+    where
+        T: IntoIterator,
+        T::Item: std::string::ToString,
+    {
         for item in items {
             self.items.push(item.to_string());
             self.defaults.push(false);
@@ -100,8 +104,12 @@ impl MultiSelect<'_> {
     }
 
     /// Adds multiple items to the selector with checked state
-    pub fn items_checked<T: ToString>(&mut self, items: &[(T, bool)]) -> &mut Self {
-        for &(ref item, checked) in items {
+    pub fn items_checked<T, I>(&mut self, items: T) -> &mut Self
+    where
+        I: std::string::ToString,
+        T: IntoIterator<Item = (I, bool)>,
+    {
+        for (item, checked) in items {
             self.items.push(item.to_string());
             self.defaults.push(checked);
         }

--- a/src/prompts/multi_select.rs
+++ b/src/prompts/multi_select.rs
@@ -93,8 +93,8 @@ impl MultiSelect<'_> {
     /// Adds multiple items to the selector.
     pub fn items<T>(&mut self, items: T) -> &mut Self
     where
+        T::Item: ToString,
         T: IntoIterator,
-        T::Item: std::string::ToString,
     {
         for item in items {
             self.items.push(item.to_string());
@@ -106,7 +106,7 @@ impl MultiSelect<'_> {
     /// Adds multiple items to the selector with checked state
     pub fn items_checked<T, I>(&mut self, items: T) -> &mut Self
     where
-        I: std::string::ToString,
+        I: ToString,
         T: IntoIterator<Item = (I, bool)>,
     {
         for (item, checked) in items {

--- a/src/prompts/select.rs
+++ b/src/prompts/select.rs
@@ -123,7 +123,11 @@ impl Select<'_> {
     ///     Ok(())
     /// }
     /// ```
-    pub fn items<T: ToString>(&mut self, items: &[T]) -> &mut Self {
+    pub fn items<T: ToString>(&mut self, items: T) -> &mut Self
+    where
+        T: IntoIterator,
+        T::Item: std::string::ToString,
+    {
         for item in items {
             self.items.push(item.to_string());
         }

--- a/src/prompts/select.rs
+++ b/src/prompts/select.rs
@@ -125,8 +125,8 @@ impl Select<'_> {
     /// ```
     pub fn items<T>(&mut self, items: T) -> &mut Self
     where
-        T::Item: ToString,
         T: IntoIterator,
+        T::Item: ToString,
     {
         for item in items {
             self.items.push(item.to_string());

--- a/src/prompts/select.rs
+++ b/src/prompts/select.rs
@@ -123,10 +123,10 @@ impl Select<'_> {
     ///     Ok(())
     /// }
     /// ```
-    pub fn items<T: ToString>(&mut self, items: T) -> &mut Self
+    pub fn items<T>(&mut self, items: T) -> &mut Self
     where
+        T::Item: ToString,
         T: IntoIterator,
-        T::Item: std::string::ToString,
     {
         for item in items {
             self.items.push(item.to_string());

--- a/src/prompts/sort.rs
+++ b/src/prompts/sort.rs
@@ -76,8 +76,8 @@ impl Sort<'_> {
     /// Adds multiple items to the selector.
     pub fn items<T>(&mut self, items: T) -> &mut Self
     where
+        T::Item: ToString,
         T: IntoIterator,
-        T::Item: std::string::ToString,
     {
         for item in items {
             self.items.push(item.to_string());

--- a/src/prompts/sort.rs
+++ b/src/prompts/sort.rs
@@ -74,7 +74,11 @@ impl Sort<'_> {
     }
 
     /// Adds multiple items to the selector.
-    pub fn items<T: ToString>(&mut self, items: &[T]) -> &mut Self {
+    pub fn items<T>(&mut self, items: T) -> &mut Self
+    where
+        T: IntoIterator,
+        T::Item: std::string::ToString,
+    {
         for item in items {
             self.items.push(item.to_string());
         }

--- a/src/prompts/sort.rs
+++ b/src/prompts/sort.rs
@@ -76,8 +76,8 @@ impl Sort<'_> {
     /// Adds multiple items to the selector.
     pub fn items<T>(&mut self, items: T) -> &mut Self
     where
-        T::Item: ToString,
         T: IntoIterator,
+        T::Item: ToString,
     {
         for item in items {
             self.items.push(item.to_string());


### PR DESCRIPTION
This allows for much more flexibility when generating prompts. The user can pass in, for example, the output of a `.map` without having to collect it into a vector and provide a slice.
Since all these functions do is run a simple for loop over the input, it's an easy change to make. Existing code should continue to work, as &[T] implements IntoIterator<Item: T> by default.