### PR TITLE
Return Err on Confirm's read_key when not a terminal

### DIFF
--- a/src/prompts/confirm.rs
+++ b/src/prompts/confirm.rs
@@ -206,6 +206,12 @@ impl Confirm<'_> {
                     Key::Escape | Key::Char('q') if allow_quit => {
                         value = None;
                     }
+                    Key::Unknown => {
+                        return Err(io::Error::new(
+                            io::ErrorKind::NotConnected,
+                            "Not a terminal",
+                        ))
+                    }
                     _ => {
                         continue;
                     }
@@ -224,6 +230,12 @@ impl Confirm<'_> {
                     Key::Char('n') | Key::Char('N') => Some(false),
                     Key::Enter if self.default.is_some() => Some(self.default.unwrap()),
                     Key::Escape | Key::Char('q') if allow_quit => None,
+                    Key::Unknown => {
+                        return Err(io::Error::new(
+                            io::ErrorKind::NotConnected,
+                            "Not a terminal",
+                        ))
+                    }
                     _ => {
                         continue;
                     }


### PR DESCRIPTION
Resolves #148