### PR TITLE
Fix long lines in select failing size calcuations

### DIFF
--- a/src/edit.rs
+++ b/src/edit.rs
@@ -104,9 +104,7 @@ impl Editor {
                 let cmd = parts.remove(0);
                 (cmd, parts)
             }
-            Err(_) => {
-                (s, vec![])
-            }
+            Err(_) => (s, vec![]),
         };
 
         let rv = process::Command::new(cmd)

--- a/src/theme.rs
+++ b/src/theme.rs
@@ -958,10 +958,13 @@ impl<'a> TermThemeRenderer<'a> {
 
     pub fn clear_preserve_prompt(&mut self, size_vec: &[usize]) -> io::Result<()> {
         let mut new_height = self.height;
+        let prefix_width = 2;
         //Check each item size, increment on finding an overflow
         for size in size_vec {
             if *size > self.term.size().1 as usize {
-                new_height += 1;
+                new_height += (((*size as f64 + prefix_width as f64) / self.term.size().1 as f64)
+                    .ceil()) as usize
+                    - 1;
             }
         }
 


### PR DESCRIPTION
Hi there,

I had a look into what the cause of the issue is for #237.
It turns out in the calculation for `clear_preserve_prompt` we assume it would only be a single new line that could be added per item but a line could expand easily to 3 or more lines. So I added a calculation to add as many lines as needed here.

I hard coded the `prefix_width` as I believe it's not adjustable to be more than 2 but I wasn't sure and I only tested with `Select`. Tests seem to pass though. Happy to make this bit dynamic (which is why I called it out as an extra variable) but wanted to check here first.

- [x] ran `cargo fmt`
- [x] ran `cargo clippy` (though ignored most of the errors here and only checked for warnings or errors for my changed code
- [x] ran `cargo test`

Fixes #237