### PR TITLE
Polish CI

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,5 +1,5 @@
 [alias]
 format       = "fmt"
 format-check = "fmt --check"
-lint         = "clippy --all-targets --all-features --examples --tests -- -D warnings"
+lint         = "clippy --all-targets --all-features -- -D warnings"
 test-cover   = "llvm-cov --all-features --lcov --output-path lcov.info"

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,5 +1,5 @@
 [alias]
 format       = "fmt"
-format-check = "fmt -- --check"
+format-check = "fmt --check"
 lint         = "clippy --all-targets --all-features --examples --tests -- -D warnings"
 test-cover   = "llvm-cov --all-features --lcov --output-path lcov.info"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,12 +32,10 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Install rust
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@master
         with:
-          profile: minimal
           toolchain: ${{ matrix.rust }}
-          target: ${{ matrix.target }}
-          override: true
+          targets: ${{ matrix.target }}
       - name: Checkout
         uses: actions/checkout@v3
       - name: Install linker
@@ -46,28 +44,20 @@ jobs:
           sudo apt-get update
           sudo apt-get install gcc-multilib
       - name: Test
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --all-features --target ${{ matrix.target }}
+        run: cargo test --all-features --target ${{ matrix.target }}
+
   lint:
     name: Linting (fmt + clippy)
     runs-on: ubuntu-latest
     steps:
       - name: Install rust
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@master
         with:
-          profile: minimal
           toolchain: 1.59.0
-          override: true
           components: rustfmt, clippy
       - name: Checkout
         uses: actions/checkout@v3
       - name: Lint check
-        uses: actions-rs/cargo@v1
-        with:
-          command: lint
+        run: cargo lint
       - name: Format check
-        uses: actions-rs/cargo@v1
-        with:
-          command: format-check
+        run: cargo format-check

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,9 +51,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Install rust
-        uses: dtolnay/rust-toolchain@master
+        uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: 1.59.0
           components: rustfmt, clippy
       - name: Checkout
         uses: actions/checkout@v3


### PR DESCRIPTION
- The big item here is switching away from actions-rs since the entire organization is unmaintained and the actions are starting to fall apart. 
- The second item is switching the lint job from running with the MSRV to stable, so dialoguer doesn't miss out on newer lints.
- The other two commits are just nits without any functional change.
 
See the individual commits for details.