### PR TITLE
Do not error on Key::Unknown in input and confirm

### DIFF
--- a/src/prompts/confirm.rs
+++ b/src/prompts/confirm.rs
@@ -194,12 +194,6 @@ impl Confirm<'_> {
                     Key::Escape | Key::Char('q') if allow_quit => {
                         value = None;
                     }
-                    Key::Unknown => {
-                        return Err(io::Error::new(
-                            io::ErrorKind::NotConnected,
-                            "Not a terminal",
-                        ))?;
-                    }
                     _ => {
                         continue;
                     }
@@ -218,12 +212,6 @@ impl Confirm<'_> {
                     Key::Char('n') | Key::Char('N') => Some(false),
                     Key::Enter if self.default.is_some() => Some(self.default.unwrap()),
                     Key::Escape | Key::Char('q') if allow_quit => None,
-                    Key::Unknown => {
-                        return Err(io::Error::new(
-                            io::ErrorKind::NotConnected,
-                            "Not a terminal",
-                        ))?;
-                    }
                     _ => {
                         continue;
                     }


### PR DESCRIPTION
On windows if you hit `Ctrl` or some other unmapped key the confirm prompt fails with an error otherwise.