### PR TITLE
Record input to history before validation

### DIFF
--- a/src/prompts/input.rs
+++ b/src/prompts/input.rs
@@ -592,16 +592,16 @@ where
 
             match input.parse::<T>() {
                 Ok(value) => {
+                    #[cfg(feature = "history")]
+                    if let Some(history) = &mut self.history {
+                        history.write(&value);
+                    }
+
                     if let Some(ref mut validator) = self.validator {
                         if let Some(err) = validator(&value) {
                             render.error(&err)?;
                             continue;
                         }
-                    }
-
-                    #[cfg(feature = "history")]
-                    if let Some(history) = &mut self.history {
-                        history.write(&value);
                     }
 
                     if self.report {


### PR DESCRIPTION
One of the main reasons to use `history` is the ability to correct mistakes.
When used with validation, history is appended after validation, so the input not passing it doesn't end up in history.
Therefore, the user needs to re-type the whole text.

With this PR, history is written before input validation, so we have a complete history. This behavior is in line with tools like `bash`.

```rust
Input::with_theme(&theme)
    .with_prompt("E-mail")
    .history_with(&mut history)
    .validate_with(|email: &String| -> Result<(), String> {
        if !email.contains('@') {
            return Err(format!("{}: '{}'", "Invalid email address", email));
        }
    })
    .interact_text()
    .expect("Unable to read email")

```