### PR TITLE
Update MSRV to 1.59 -> 1.63

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,19 +13,19 @@ jobs:
         include:
           - os: macos-latest
             target: x86_64-apple-darwin
-            rust: 1.59.0
+            rust: 1.63.0
           - os: ubuntu-latest
             target: x86_64-unknown-linux-gnu
-            rust: 1.59.0
+            rust: 1.63.0
           - os: ubuntu-latest
             target: i686-unknown-linux-gnu
-            rust: 1.59.0
+            rust: 1.63.0
           - os: windows-latest
             target: i686-pc-windows-msvc
-            rust: 1.59.0
+            rust: 1.63.0
           - os: windows-latest
             target: x86_64-pc-windows-msvc
-            rust: 1.59.0
+            rust: 1.63.0
           - os: ubuntu-latest
             target: x86_64-unknown-linux-gnu
             rust: stable

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 
 ### Breaking
 
-* Updated MSRV to `1.59.0`
+* Updated MSRV to `1.63.0` due to multiple dependencies on different platforms: `rustix`, `tempfile`,`linux-raw-sys`
 * Removed deprecated `Confirm::with_text`
 * Prompt builder functions now take `mut self` instead of `&mut self`
 * Prompt builder functions now return `Self` instead of `&mut Self`

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ name = "dialoguer"
 description = "A command line prompting library."
 version = "0.10.4"
 edition = "2021"
-rust-version = "1.59.0"
+rust-version = "1.63.0"
 authors = [
 	"Armin Ronacher <armin.ronacher@active-4.com>",
 	"Pavan Kumar Sunkara <pavan.sss1991@gmail.com>"


### PR DESCRIPTION
Found your CI failing.
The easiest is to bump MSRV since 5 months passed after the previous update.

This fixes failing CI on 44cb900