### PR TITLE
Change chars for `MultiSelect` items

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 * Added `dialouger::Result` and `dialouger::Error`
 * Resolve some issues on Windows where pressing shift keys sometimes aborted dialogs.
+* Resolve `MultiSelect` checked and unchecked variants looking the same on Windows. More compatible '✔️' and '❌' used instead of '✔' colors.
 
 ### Breaking
 

--- a/src/theme/colorful.rs
+++ b/src/theme/colorful.rs
@@ -71,8 +71,8 @@ impl Default for ColorfulTheme {
             inactive_item_style: Style::new().for_stderr(),
             active_item_prefix: style("❯".to_string()).for_stderr().green(),
             inactive_item_prefix: style(" ".to_string()).for_stderr(),
-            checked_item_prefix: style("✔".to_string()).for_stderr().green(),
-            unchecked_item_prefix: style("✔".to_string()).for_stderr().black(),
+            checked_item_prefix: style("✔️".to_string()).for_stderr().blue(),
+            unchecked_item_prefix: style("❌".to_string()).for_stderr().red(),
             picked_item_prefix: style("❯".to_string()).for_stderr().green(),
             unpicked_item_prefix: style(" ".to_string()).for_stderr(),
             #[cfg(feature = "fuzzy-select")]


### PR DESCRIPTION
Windows Terminal, a widely used terminal emulator for some reason does not support coloring for '✔' char.
'✔️' and '❌' may be used instead. They work down to the previous Windows terminal emulator: `conhost.exe`.

## Before: 

### Windows Terminal 
![image](https://github.com/Gordon01/dialoguer/assets/4996834/7649fbe7-3f77-4f64-970b-d5b2f8a22267)
As you can see, selected and unselected items are indistinguishable.


### `conhost.exe`

![image](https://github.com/Gordon01/dialoguer/assets/4996834/64f59e6c-523c-4df8-b663-33aaffad2b5c)
Surprisingly, the old windows emulator is better than new one. 

### VSCode
![image](https://github.com/Gordon01/dialoguer/assets/4996834/a95ee035-55f2-4118-b534-71634a29804b)

## After:

### Windows Terminal 

![image](https://github.com/Gordon01/dialoguer/assets/4996834/391d6fa4-805d-42cb-a724-837584d21179)

### `conhost.exe`

![image](https://github.com/Gordon01/dialoguer/assets/4996834/dc3b52f6-7adb-45cd-b31e-9f48d53b7b44)

### VSCode

![image](https://github.com/Gordon01/dialoguer/assets/4996834/d2b9a48c-4387-4636-b435-29a3fd3b8b82)
