### PR TITLE
Count characters in `password` example instead of bytes

### DIFF
--- a/examples/password.rs
+++ b/examples/password.rs
@@ -5,7 +5,7 @@ fn main() {
         .with_prompt("Password")
         .with_confirmation("Repeat password", "Error: the passwords don't match.")
         .validate_with(|input: &String| -> Result<(), &str> {
-            if input.len() > 3 {
+            if input.chars().count() > 3 {
                 Ok(())
             } else {
                 Err("Password must be longer than 3")
@@ -14,5 +14,8 @@ fn main() {
         .interact()
         .unwrap();
 
-    println!("Your password is {} characters long", password.len());
+    println!(
+        "Your password is {} characters long",
+        password.chars().count()
+    );
 }

--- a/src/prompts/password.rs
+++ b/src/prompts/password.rs
@@ -159,7 +159,7 @@ impl<'a> Password<'a> {
     ///     let password: String = Password::new()
     ///         .with_prompt("Enter password")
     ///         .validate_with(|input: &String| -> Result<(), &str> {
-    ///             if input.len() > 8 {
+    ///             if input.chars().count() > 8 {
     ///                 Ok(())
     ///             } else {
     ///                 Err("Password must be longer than 8")

--- a/src/prompts/password.rs
+++ b/src/prompts/password.rs
@@ -86,7 +86,7 @@ impl Password<'_> {
 
     /// Enables user interaction and returns the result.
     ///
-    /// If the user confirms the result is `true`, `false` otherwise.
+    /// If the user confirms the result is `Ok()`, `Err()` otherwise.
     /// The dialog is rendered on stderr.
     pub fn interact(self) -> Result<String> {
         self.interact_on(&Term::stderr())


### PR DESCRIPTION
A `password` example contains a typical Rust bug when String's number of bytes is checked instead of characters.

`Password::interact_on()` doc is updated here too.