### PR TITLE
Input opt

### DIFF
--- a/src/prompts/input.rs
+++ b/src/prompts/input.rs
@@ -289,6 +289,7 @@ where
     ///
     /// The dialog is rendered on stderr.
     /// This unlike [`interact_text_opt`](Self::interact_text_opt) does not allow to quit with 'Esc'
+    #[inline]
     pub fn interact_text(self) -> Result<T> {
         self.interact_text_on(&Term::stderr())
     }

--- a/src/prompts/input.rs
+++ b/src/prompts/input.rs
@@ -1,6 +1,5 @@
 use std::{
     cmp::Ordering,
-    fmt::Debug,
     io, iter,
     str::FromStr,
     sync::{Arc, Mutex},
@@ -281,7 +280,7 @@ where
 impl<T> Input<'_, T>
 where
     T: Clone + ToString + FromStr,
-    <T as FromStr>::Err: Debug + ToString,
+    <T as FromStr>::Err: ToString,
 {
     /// Enables the user to enter a printable ascii sequence and returns the result.
     ///
@@ -338,11 +337,6 @@ where
                     None
                 },
             )?;
-
-            // Read input by keystroke so that we can suppress ascii control characters
-            if !term.features().is_attended() {
-                return Ok(Some("".to_owned().parse::<T>().unwrap()));
-            }
 
             let mut chars: Vec<char> = Vec::new();
             let mut position = 0;
@@ -661,13 +655,7 @@ where
             }
         }
     }
-}
 
-impl<T> Input<'_, T>
-where
-    T: Clone + ToString + FromStr,
-    <T as FromStr>::Err: ToString,
-{
     /// Enables user interaction and returns the result.
     ///
     /// Allows any characters as input, including e.g arrow keys.


### PR DESCRIPTION
Hello,
This adds 'interact_text_opt' and 'interact_text_on_opt' for 'Input' prompts (see #160)

Note I did not do the same for 'interact' methods, I don't see how this would work with escape sequences being accepted.

P.S: Is there a specific process to contribute or is opening a pull request fine ?