### PR TITLE
Add '1' and '0' as allowed keys for `Confirm`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * Added a `BasicHistory` implementation for `History`
 * Added vim mode for `FuzzySelect`
 * All prompts implement `Clone`
+* `Confirm` now also accepts '1' and '0' as confirmations for international accessibility
 
 ### Bug fixes
 

--- a/src/prompts/confirm.rs
+++ b/src/prompts/confirm.rs
@@ -68,11 +68,11 @@ impl Confirm<'_> {
     /// Sets when to react to user input.
     ///
     /// When `false` (default), we check on each user keystroke immediately as
-    /// it is typed. Valid inputs can be one of 'y', 'n', or a newline to accept
+    /// it is typed. Valid inputs can be one of 'y', 'n', '1', '0' or a newline to accept
     /// the default.
     ///
     /// When `true`, the user must type their choice and hit the Enter key before
-    /// proceeding. Valid inputs can be "yes", "no", "y", "n", or an empty string
+    /// proceeding. Valid inputs can be "yes", "no", "y", "n", "1", "0" or an empty string
     /// to accept the default.
     pub fn wait_for_newline(mut self, wait: bool) -> Self {
         self.wait_for_newline = wait;
@@ -179,10 +179,10 @@ impl Confirm<'_> {
                 let input = term.read_key()?;
 
                 match input {
-                    Key::Char('y') | Key::Char('Y') => {
+                    Key::Char('y') | Key::Char('Y') | Key::Char('1') => {
                         value = Some(true);
                     }
-                    Key::Char('n') | Key::Char('N') => {
+                    Key::Char('n') | Key::Char('N') | Key::Char('0') => {
                         value = Some(false);
                     }
                     Key::Enter => {
@@ -213,8 +213,8 @@ impl Confirm<'_> {
             loop {
                 let input = term.read_key()?;
                 let value = match input {
-                    Key::Char('y') | Key::Char('Y') => Some(true),
-                    Key::Char('n') | Key::Char('N') => Some(false),
+                    Key::Char('y') | Key::Char('Y') | Key::Char('1') => Some(true),
+                    Key::Char('n') | Key::Char('N') | Key::Char('0') => Some(false),
                     Key::Enter if self.default.is_some() => Some(self.default.unwrap()),
                     Key::Escape | Key::Char('q') if allow_quit => None,
                     _ => {

--- a/src/theme/colorful.rs
+++ b/src/theme/colorful.rs
@@ -153,20 +153,20 @@ impl Theme for ColorfulTheme {
             None => write!(
                 f,
                 "{} {}",
-                self.hint_style.apply_to("(y/n)"),
+                self.hint_style.apply_to("(y/n or 1/0)"),
                 &self.prompt_suffix
             ),
             Some(true) => write!(
                 f,
                 "{} {} {}",
-                self.hint_style.apply_to("(y/n)"),
+                self.hint_style.apply_to("(y/n or 1/0)"),
                 &self.prompt_suffix,
                 self.defaults_style.apply_to("yes")
             ),
             Some(false) => write!(
                 f,
                 "{} {} {}",
-                self.hint_style.apply_to("(y/n)"),
+                self.hint_style.apply_to("(y/n or 1/0)"),
                 &self.prompt_suffix,
                 self.defaults_style.apply_to("no")
             ),

--- a/src/theme/mod.rs
+++ b/src/theme/mod.rs
@@ -38,9 +38,9 @@ pub trait Theme {
             write!(f, "{} ", &prompt)?;
         }
         match default {
-            None => write!(f, "[y/n] ")?,
-            Some(true) => write!(f, "[Y/n] ")?,
-            Some(false) => write!(f, "[y/N] ")?,
+            None => write!(f, "[y/n or 1/0] ")?,
+            Some(true) => write!(f, "[Y/n or 1/0] ")?,
+            Some(false) => write!(f, "[y/N or 1/0] ")?,
         }
         Ok(())
     }


### PR DESCRIPTION
Fixes: https://github.com/console-rs/dialoguer/issues/256

In an effort to foster a more inclusive and accessible user interface, this PR introduces '1' and '0' as alternative input options alongside 'y' and 'n' in the text confirmation prompt. 
