### PR TITLE
Remove dead code and  'Debug' trait bound on Input's 'interact_text*' methods

### DIFF
--- a/src/prompts/input.rs
+++ b/src/prompts/input.rs
@@ -1,6 +1,5 @@
 use std::{
     cmp::Ordering,
-    fmt::Debug,
     io, iter,
     str::FromStr,
     sync::{Arc, Mutex},
@@ -281,7 +280,7 @@ where
 impl<T> Input<'_, T>
 where
     T: Clone + ToString + FromStr,
-    <T as FromStr>::Err: Debug + ToString,
+    <T as FromStr>::Err: ToString,
 {
     /// Enables the user to enter a printable ascii sequence and returns the result.
     ///
@@ -312,11 +311,6 @@ where
                     None
                 },
             )?;
-
-            // Read input by keystroke so that we can suppress ascii control characters
-            if !term.features().is_attended() {
-                return Ok("".to_owned().parse::<T>().unwrap());
-            }
 
             let mut chars: Vec<char> = Vec::new();
             let mut position = 0;
@@ -629,13 +623,7 @@ where
             }
         }
     }
-}
 
-impl<T> Input<'_, T>
-where
-    T: Clone + ToString + FromStr,
-    <T as FromStr>::Err: ToString,
-{
     /// Enables user interaction and returns the result.
     ///
     /// Allows any characters as input, including e.g arrow keys.


### PR DESCRIPTION
Extracted from #278 as requested.
The "term.features().is_attended()" check can never be reached because "term.is_term()" is checked at the beginning of the method (iiuc the checks are strictly equivalent).

Additionnally, the 'unwrap' call in the dead code forced a 'Debug' trait bound on the <T as FromStr>::Err associated type.

Therefore i removed both the dead code and the now unnecessary trait bound. 