### PR TITLE
fix #281 : Select : prompt is no longer displayed

### DIFF
--- a/src/paging.rs
+++ b/src/paging.rs
@@ -50,7 +50,6 @@ impl<'a> Paging<'a> {
             self.current_page = cursor_pos / self.capacity;
         }
     }
-    
 
     /// Updates all internal based on the current terminal size and cursor position
     pub fn update(&mut self, cursor_pos: usize) -> Result {

--- a/src/paging.rs
+++ b/src/paging.rs
@@ -42,6 +42,16 @@ impl<'a> Paging<'a> {
         }
     }
 
+    pub fn update_page(&mut self, cursor_pos: usize) {
+        if cursor_pos != !0
+            && (cursor_pos < self.current_page * self.capacity
+                || cursor_pos >= (self.current_page + 1) * self.capacity)
+        {
+            self.current_page = cursor_pos / self.capacity;
+        }
+    }
+    
+
     /// Updates all internal based on the current terminal size and cursor position
     pub fn update(&mut self, cursor_pos: usize) -> Result {
         let new_term_size = self.term.size();
@@ -65,12 +75,7 @@ impl<'a> Paging<'a> {
             self.term.clear_last_lines(self.capacity)?;
         }
 
-        if cursor_pos != !0
-            && (cursor_pos < self.current_page * self.capacity
-                || cursor_pos >= (self.current_page + 1) * self.capacity)
-        {
-            self.current_page = cursor_pos / self.capacity;
-        }
+        self.update_page(cursor_pos);
 
         Ok(())
     }

--- a/src/prompts/select.rs
+++ b/src/prompts/select.rs
@@ -214,7 +214,7 @@ impl Select<'_> {
         }
 
         term.hide_cursor()?;
-        paging.update(sel)?;
+        paging.update_page(sel);
 
         loop {
             if let Some(ref prompt) = self.prompt {


### PR DESCRIPTION
Hello,

I extracted the recomputation of the page into a separate method to fix the default selection not being on the first page without hiding the prompt.
