### PR TITLE
Fix prompt in `select.rs` example

### DIFF
--- a/examples/select.rs
+++ b/examples/select.rs
@@ -31,7 +31,7 @@ fn main() {
     }
 
     let selection = Select::with_theme(&ColorfulTheme::default())
-        .with_prompt("Optionally pick your flavor, hint it might be on the second page")
+        .with_prompt("Pick your flavor, hint it might be on the second page")
         .default(0)
         .max_length(2)
         .items(&selections[..])


### PR DESCRIPTION
The prompt for the third dialogue in `examples/select.rs` says "Optionally pick your flavor", but the choice is not optional.  This PR removes the word "Optionally."