### PR TITLE
Document crate feature guarded items on docs.rs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,4 +56,5 @@ required-features = ["completion"]
 no_individual_tags = true
 
 [package.metadata.docs.rs]
+rustdoc-args = ["--cfg", "docsrs"]
 all-features = true

--- a/src/error.rs
+++ b/src/error.rs
@@ -10,5 +10,5 @@ pub enum Error {
     IO(#[from] IoError),
 }
 
-/// Result type where errors are of type [Error](crate::error::Error)
+/// Result type where errors are of type [Error](enum@Error).
 pub type Result<T = ()> = StdResult<T, Error>;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,6 +30,7 @@
 //! By default `editor` and `password` are enabled.
 
 #![deny(clippy::all)]
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 
 pub use console;
 


### PR DESCRIPTION
this nightly feature is plenty stable and shows some decent benefits for this crate

before and after:

<table>
<tr>
 <td>

![2023-11-29_11 59 18-aeffa722](https://github.com/console-rs/dialoguer/assets/3316789/9b132103-1f04-4676-9383-63a760779fd4)


</td>
 <td>

![2023-11-29_11 59 15-0f90ebbc](https://github.com/console-rs/dialoguer/assets/3316789/8db3f8a9-9f77-41f8-9037-4b1a90dd60e0)


</td>
</table>