### PR TITLE
Accept items by iterator instead of slice

### DIFF
--- a/src/prompts/fuzzy_select.rs
+++ b/src/prompts/fuzzy_select.rs
@@ -81,10 +81,14 @@ impl FuzzySelect<'_> {
     }
 
     /// Adds multiple items to the fuzzy selector.
-    pub fn items<T: ToString>(mut self, items: &[T]) -> Self {
-        for item in items {
-            self.items.push(item.to_string());
-        }
+    pub fn items<T, I>(mut self, items: I) -> Self
+    where
+        T: ToString,
+        I: IntoIterator<Item = T>,
+    {
+        self.items
+            .extend(items.into_iter().map(|item| item.to_string()));
+
         self
     }
 

--- a/src/prompts/fuzzy_select.rs
+++ b/src/prompts/fuzzy_select.rs
@@ -408,4 +408,12 @@ mod tests {
 
         let _ = fuzzy_select.clone();
     }
+
+    #[test]
+    fn test_iterator() {
+        let items = ["First", "Second", "Third"];
+        let iterator = items.iter().skip(1);
+
+        assert_eq!(FuzzySelect::new().items(iterator).items, &items[1..]);
+    }
 }

--- a/src/prompts/multi_select.rs
+++ b/src/prompts/multi_select.rs
@@ -101,17 +101,21 @@ impl MultiSelect<'_> {
     }
 
     /// Adds multiple items to the selector.
-    pub fn items<T: ToString>(mut self, items: &[T]) -> Self {
-        for item in items {
-            self.items.push(item.to_string());
-            self.defaults.push(false);
-        }
-        self
+    pub fn items<T, I>(self, items: I) -> Self
+    where
+        T: ToString,
+        I: IntoIterator<Item = T>,
+    {
+        self.items_checked(items.into_iter().map(|item| (item, false)))
     }
 
     /// Adds multiple items to the selector with checked state
-    pub fn items_checked<T: ToString>(mut self, items: &[(T, bool)]) -> Self {
-        for &(ref item, checked) in items {
+    pub fn items_checked<T, I>(mut self, items: I) -> Self
+    where
+        T: ToString,
+        I: IntoIterator<Item = (T, bool)>,
+    {
+        for (item, checked) in items.into_iter() {
             self.items.push(item.to_string());
             self.defaults.push(checked);
         }

--- a/src/prompts/multi_select.rs
+++ b/src/prompts/multi_select.rs
@@ -386,4 +386,12 @@ mod tests {
 
         let _ = multi_select.clone();
     }
+
+    #[test]
+    fn test_iterator() {
+        let items = ["First", "Second", "Third"];
+        let iterator = items.iter().skip(1);
+
+        assert_eq!(MultiSelect::new().items(iterator).items, &items[1..]);
+    }
 }

--- a/src/prompts/select.rs
+++ b/src/prompts/select.rs
@@ -99,14 +99,19 @@ impl Select<'_> {
     /// ```
     pub fn item<T: ToString>(mut self, item: T) -> Self {
         self.items.push(item.to_string());
+
         self
     }
 
     /// Adds multiple items to the selector.
-    pub fn items<T: ToString>(mut self, items: &[T]) -> Self {
-        for item in items {
-            self.items.push(item.to_string());
-        }
+    pub fn items<T, I>(mut self, items: I) -> Self
+    where
+        T: ToString,
+        I: IntoIterator<Item = T>,
+    {
+        self.items
+            .extend(items.into_iter().map(|item| item.to_string()));
+
         self
     }
 

--- a/src/prompts/select.rs
+++ b/src/prompts/select.rs
@@ -368,7 +368,7 @@ mod tests {
         let selections = vec!["a".to_string(), "b".to_string()];
 
         assert_eq!(
-            Select::new().default(0).items(&selections[..]).items,
+            Select::new().default(0).items(&selections).items,
             selections
         );
     }
@@ -380,9 +380,14 @@ mod tests {
 
         let selections = &[a, b];
 
-        assert_eq!(
-            Select::new().default(0).items(&selections[..]).items,
-            selections
-        );
+        assert_eq!(Select::new().default(0).items(selections).items, selections);
+    }
+
+    #[test]
+    fn test_iterator() {
+        let items = ["First", "Second", "Third"];
+        let iterator = items.iter().skip(1);
+
+        assert_eq!(Select::new().default(0).items(iterator).items, &items[1..]);
     }
 }

--- a/src/prompts/sort.rs
+++ b/src/prompts/sort.rs
@@ -83,10 +83,14 @@ impl Sort<'_> {
     }
 
     /// Adds multiple items to the selector.
-    pub fn items<T: ToString>(mut self, items: &[T]) -> Self {
-        for item in items {
-            self.items.push(item.to_string());
-        }
+    pub fn items<T, I>(mut self, items: I) -> Self
+    where
+        T: ToString,
+        I: IntoIterator<Item = T>,
+    {
+        self.items
+            .extend(items.into_iter().map(|item| item.to_string()));
+
         self
     }
 

--- a/src/prompts/sort.rs
+++ b/src/prompts/sort.rs
@@ -377,4 +377,12 @@ mod tests {
 
         let _ = sort.clone();
     }
+
+    #[test]
+    fn test_iterator() {
+        let items = ["First", "Second", "Third"];
+        let iterator = items.iter().skip(1);
+
+        assert_eq!(Sort::new().items(iterator).items, &items[1..]);
+    }
 }


### PR DESCRIPTION
## Description

Replaces the handling for adding multiple items to the `Select`, `FuzzySelect`, `MultiSelect`, and `Sort` they currently take a slice containing any number of values that can be converted into `String` through `ToString`, this change replaces taking a slice with instead taking anything that implement `IntoIterator` where the item is `ToString`.

This allows the items function to take any collection of values rather than only allowing slices, thus making something like the following possible: 
```rust

struct MyItem {
  name: String,
  // .. other struct items
}

let collection: Vec<MyItem> = vec![  /* Some list of items */ ];
let item_names = collection
  .iter()
  .map(|item| item.name.as_str());

Select::new()
  .items(item_names);
```

## Changes

- Make `items`, `items_checked` (and similar functions) accept an iterator instead of a slice
- Add tests for the new iterator items function 