### PR TITLE
Add conversion between error types

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -12,3 +12,13 @@ pub enum Error {
 
 /// Result type where errors are of type [Error](enum@Error).
 pub type Result<T = ()> = StdResult<T, Error>;
+
+impl From<Error> for IoError {
+    fn from(value: Error) -> Self {
+        match value {
+            Error::IO(err) => err,
+            // If other error types are added in the future:
+            // err => IoError::new(std::io::ErrorKind::Other, err),
+        }
+    }
+}


### PR DESCRIPTION
## Description

Implements `From` for `Error` for `std::io::Error` to allow the error type to be converted to a `std::io::Error` which makes it easier for those coming from the v0.10 version where it was using std::io::Error instead of a custom error type.

This makes it easier to deal with the error type for those in a console app who are already likely using `std::io::Result` as their return type (So they can use the try operator without having to map the error type).

Since the `std::io::Error` is flexible and can take any kind of error type as its cause. I've left a comment incase you decide to expand the error type to have more errors other than just `std::io::Error`

## Changes

- Allow conversion from `Error` to `std::io::Error`