### PR TITLE
Introduce MultiSelectPlus

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -49,7 +49,7 @@ pub use prompts::fuzzy_select::FuzzySelect;
 #[cfg(feature = "password")]
 pub use prompts::password::Password;
 pub use prompts::{
-    confirm::Confirm, input::Input, multi_select::MultiSelect, select::Select, sort::Sort,
+    confirm::Confirm, input::Input, multi_select::MultiSelect, multi_select_plus::MultiSelectPlus, multi_select_plus::MultiSelectPlusItem, select::Select, sort::Sort,
 };
 
 #[cfg(feature = "completion")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -49,7 +49,9 @@ pub use prompts::fuzzy_select::FuzzySelect;
 #[cfg(feature = "password")]
 pub use prompts::password::Password;
 pub use prompts::{
-    confirm::Confirm, input::Input, multi_select::MultiSelect, multi_select_plus::MultiSelectPlus, multi_select_plus::MultiSelectPlusItem, select::Select, sort::Sort,
+    confirm::Confirm, input::Input, multi_select::MultiSelect, multi_select_plus::MultiSelectPlus,
+    multi_select_plus::MultiSelectPlusItem, multi_select_plus::MultiSelectPlusStatus,
+    select::Select, sort::Sort,
 };
 
 #[cfg(feature = "completion")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -50,7 +50,7 @@ pub use prompts::fuzzy_select::FuzzySelect;
 pub use prompts::password::Password;
 pub use prompts::{
     confirm::Confirm, input::Input, multi_select::MultiSelect, multi_select_plus::MultiSelectPlus,
-    multi_select_plus::MultiSelectPlusItem, multi_select_plus::MultiSelectPlusStatus,
+    multi_select_plus::MultiSelectPlusItem, multi_select_plus::MultiSelectPlusStatus, multi_select_plus::SelectCallback,
     select::Select, sort::Sort,
 };
 

--- a/src/prompts/mod.rs
+++ b/src/prompts/mod.rs
@@ -3,6 +3,7 @@
 pub mod confirm;
 pub mod input;
 pub mod multi_select;
+pub mod multi_select_plus;
 pub mod select;
 pub mod sort;
 

--- a/src/prompts/multi_select_plus.rs
+++ b/src/prompts/multi_select_plus.rs
@@ -1,0 +1,375 @@
+use std::{io, ops::Rem};
+
+use console::{Key, Term};
+
+use crate::{
+    Paging,
+    Result, theme::{render::TermThemeRenderer, SimpleTheme, Theme},
+};
+
+/// Renders a multi select prompt.
+///
+/// ## Example
+///
+/// ```rust,no_run
+/// use dialoguer::MultiSelectPlus;
+///
+/// fn main() {
+///     use dialoguer::MultiSelectPlusItem;
+///     let items = vec![
+///         MultiSelectPlusItem { name: "Foo", summary_text: "Foo", checked: false },
+///         MultiSelectPlusItem { name: "Bar (more details here)", summary_text: "Bar", checked: true },
+///     ];
+///
+///     let selection = MultiSelectPlus::new()
+///         .with_prompt("What do you choose?")
+///         .items(items)
+///         .interact()
+///         .unwrap();
+///
+///     println!("You chose:");
+///
+///     for i in selection {
+///         println!("{}", items[i]);
+///     }
+/// }
+/// ```
+#[derive(Clone)]
+pub struct MultiSelectPlus<'a, N: ToString + Clone, S: ToString + Clone> {
+    items: Vec<MultiSelectPlusItem<N, S>>,
+    prompt: Option<String>,
+    report: bool,
+    clear: bool,
+    max_length: Option<usize>,
+    theme: &'a dyn Theme,
+}
+
+#[derive(Clone)]
+pub struct MultiSelectPlusItem<N: ToString + Clone, S: ToString + Clone> {
+    pub name: N,
+    pub summary_text: S,
+    pub checked: bool,
+}
+
+impl<N: ToString + Clone, S: ToString + Clone> MultiSelectPlusItem<N, S> {
+    pub fn name(&self) -> &N {
+        &self.name
+    }
+
+    pub fn summary_text(&self) -> &S {
+        &self.summary_text
+    }
+
+    pub fn checked(&self) -> bool {
+        self.checked
+    }
+}
+
+impl<N: ToString + Clone, S: ToString + Clone> Default for MultiSelectPlus<'static, N, S> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl<N: ToString + Clone, S: ToString + Clone> MultiSelectPlus<'static, N, S> {
+    /// Creates a multi select prompt with default theme.
+    pub fn new() -> Self {
+        Self::with_theme(&SimpleTheme)
+    }
+}
+
+impl<N: ToString + Clone, S: ToString + Clone> MultiSelectPlus<'_, N, S> {
+    /// Sets the clear behavior of the menu.
+    ///
+    /// The default is to clear the menu.
+    pub fn clear(mut self, val: bool) -> Self {
+        self.clear = val;
+        self
+    }
+
+    /// Sets an optional max length for a page
+    ///
+    /// Max length is disabled by None
+    pub fn max_length(mut self, val: usize) -> Self {
+        // Paging subtracts two from the capacity, paging does this to
+        // make an offset for the page indicator. So to make sure that
+        // we can show the intended amount of items we need to add two
+        // to our value.
+        self.max_length = Some(val + 2);
+        self
+    }
+
+    /// Add a single item to the selector.
+    pub fn item(mut self, item: MultiSelectPlusItem<N, S>) -> Self {
+        self.items.push(item);
+        self
+    }
+
+    /// Adds multiple items to the selector.
+    pub fn items(mut self, items: Vec<MultiSelectPlusItem<N, S>>) -> Self {
+        self.items.extend(items);
+        self
+    }
+
+    /// Prefaces the menu with a prompt.
+    ///
+    /// By default, when a prompt is set the system also prints out a confirmation after
+    /// the selection. You can opt-out of this with [`report`](Self::report).
+    pub fn with_prompt<T: Into<String>>(mut self, prompt: T) -> Self {
+        self.prompt = Some(prompt.into());
+        self
+    }
+
+    /// Indicates whether to report the selected values after interaction.
+    ///
+    /// The default is to report the selections.
+    pub fn report(mut self, val: bool) -> Self {
+        self.report = val;
+        self
+    }
+
+    /// Enables user interaction and returns the result.
+    ///
+    /// The user can select the items with the 'Space' bar and on 'Enter' the indices of selected items will be returned.
+    /// The dialog is rendered on stderr.
+    /// Result contains `Vec<index>` if user hit 'Enter'.
+    /// This unlike [`interact_opt`](Self::interact_opt) does not allow to quit with 'Esc' or 'q'.
+    #[inline]
+    pub fn interact(self) -> Result<Vec<usize>> {
+        self.interact_on(&Term::stderr())
+    }
+
+    /// Enables user interaction and returns the result.
+    ///
+    /// The user can select the items with the 'Space' bar and on 'Enter' the indices of selected items will be returned.
+    /// The dialog is rendered on stderr.
+    /// Result contains `Some(Vec<index>)` if user hit 'Enter' or `None` if user cancelled with 'Esc' or 'q'.
+    ///
+    /// ## Example
+    ///
+    /// ```rust,no_run
+    /// use dialoguer::MultiSelectPlus;
+    /// use dialoguer::MultiSelectPlusItem;
+    ///
+    /// fn main() {
+    ///     let items = vec![
+    ///         MultiSelectPlusItem { name: "Foo", summary_text: "Foo", checked: false },
+    ///         MultiSelectPlusItem { name: "Bar (more details here)", summary_text: "Bar", checked: true },
+    ///     ];
+    ///
+    ///     let ordered = MultiSelectPlus::new()
+    ///         .items(items)
+    ///         .interact_opt()
+    ///         .unwrap();
+    ///
+    ///     match ordered {
+    ///         Some(positions) => {
+    ///             println!("You chose:");
+    ///
+    ///             for i in positions {
+    ///                 println!("{}", items[i]);
+    ///             }
+    ///         }
+    ///         None => println!("You did not choose anything.")
+    ///     }
+    /// }
+    /// ```
+    #[inline]
+    pub fn interact_opt(self) -> Result<Option<Vec<usize>>> {
+        self.interact_on_opt(&Term::stderr())
+    }
+
+    /// Like [`interact`](Self::interact) but allows a specific terminal to be set.
+    #[inline]
+    pub fn interact_on(self, term: &Term) -> Result<Vec<usize>> {
+        Ok(self
+            ._interact_on(term, false)?
+            .ok_or_else(|| io::Error::new(io::ErrorKind::Other, "Quit not allowed in this case"))?)
+    }
+
+    /// Like [`interact_opt`](Self::interact_opt) but allows a specific terminal to be set.
+    #[inline]
+    pub fn interact_on_opt(self, term: &Term) -> Result<Option<Vec<usize>>> {
+        self._interact_on(term, true)
+    }
+
+    fn _interact_on(mut self, term: &Term, allow_quit: bool) -> Result<Option<Vec<usize>>> {
+        if !term.is_term() {
+            return Err(io::Error::new(io::ErrorKind::NotConnected, "not a terminal").into());
+        }
+
+        if self.items.is_empty() {
+            return Err(io::Error::new(
+                io::ErrorKind::Other,
+                "Empty list of items given to `MultiSelect`",
+            ))?;
+        }
+
+        let mut paging = Paging::new(term, self.items.len(), self.max_length);
+        let mut render = TermThemeRenderer::new(term, self.theme);
+        let mut sel = 0;
+
+        let size_vec = self.items
+            .iter()
+            .flat_map(|i| i.name.to_string().split('\n').map(|s| s.len()).collect::<Vec<_>>())
+            .collect::<Vec<_>>();
+
+        term.hide_cursor()?;
+
+        loop {
+            if let Some(ref prompt) = self.prompt {
+                paging
+                    .render_prompt(|paging_info| render.multi_select_prompt(prompt, paging_info))?;
+            }
+
+            // clone to prevent mutating while waiting for input
+            let mut items = self.items.to_vec();
+
+            for (idx, item) in items
+                .iter()
+                .enumerate()
+                .skip(paging.current_page * paging.capacity)
+                .take(paging.capacity)
+            {
+                render.multi_select_prompt_item(item.name().to_string().as_str(), item.checked, sel == idx)?;
+            }
+
+            term.flush()?;
+
+            match term.read_key()? {
+                Key::ArrowDown | Key::Tab | Key::Char('j') => {
+                    if sel == !0 {
+                        sel = 0;
+                    } else {
+                        sel = (sel as u64 + 1).rem(self.items.len() as u64) as usize;
+                    }
+                }
+                Key::ArrowUp | Key::BackTab | Key::Char('k') => {
+                    if sel == !0 {
+                        sel = self.items.len() - 1;
+                    } else {
+                        sel = ((sel as i64 - 1 + self.items.len() as i64)
+                            % (self.items.len() as i64)) as usize;
+                    }
+                }
+                Key::ArrowLeft | Key::Char('h') => {
+                    if paging.active {
+                        sel = paging.previous_page();
+                    }
+                }
+                Key::ArrowRight | Key::Char('l') => {
+                    if paging.active {
+                        sel = paging.next_page();
+                    }
+                }
+                Key::Char(' ') => {
+                    items[sel].checked = !items[sel].checked;
+                    self.items = items;
+                }
+                Key::Char('a') => {
+                    if items.iter().all(|item| item.checked) {
+                        items.iter_mut().for_each(|item| item.checked = false);
+                    } else {
+                        items.iter_mut().for_each(|item| item.checked = true);
+                    }
+                }
+                Key::Escape | Key::Char('q') => {
+                    if allow_quit {
+                        if self.clear {
+                            render.clear()?;
+                        } else {
+                            term.clear_last_lines(paging.capacity)?;
+                        }
+
+                        term.show_cursor()?;
+                        term.flush()?;
+
+                        return Ok(None);
+                    }
+                }
+                Key::Enter => {
+                    if self.clear {
+                        render.clear()?;
+                    }
+
+                    if let Some(ref prompt) = self.prompt {
+                        if self.report {
+                            let selections: Vec<_> = items
+                                .iter()
+                                .enumerate()
+                                .filter_map(|(_, item)| {
+                                    if item.checked {
+                                        Some(item.summary_text.to_string())
+                                    } else {
+                                        None
+                                    }
+                                })
+                                .collect();
+
+                            render.multi_select_prompt_selection(prompt, &selections.iter().map(|s| s.as_str()).collect::<Vec<_>>())?;
+                        }
+                    }
+
+                    term.show_cursor()?;
+                    term.flush()?;
+
+                    return Ok(Some(
+                        items
+                            .into_iter()
+                            .enumerate()
+                            .filter_map(|(idx, item)| if item.checked { Some(idx) } else { None })
+                            .collect(),
+                    ));
+                }
+                _ => {}
+            }
+
+            paging.update(sel)?;
+
+            if paging.active {
+                render.clear()?;
+            } else {
+                render.clear_preserve_prompt(&size_vec)?;
+            }
+        }
+    }
+}
+
+impl<'a, N: ToString + Clone, S: ToString + Clone> MultiSelectPlus<'a, N, S> {
+    /// Creates a multi select prompt with a specific theme.
+    ///
+    /// ## Example
+    ///
+    /// ```rust,no_run
+    /// use dialoguer::{theme::ColorfulTheme, MultiSelect};
+    ///
+    /// fn main() {
+    ///     let selection = MultiSelect::with_theme(&ColorfulTheme::default())
+    ///         .items(&["foo", "bar", "baz"])
+    ///         .interact()
+    ///         .unwrap();
+    /// }
+    /// ```
+    pub fn with_theme(theme: &'a dyn Theme) -> Self {
+        Self {
+            items: vec![],
+            clear: true,
+            prompt: None,
+            report: true,
+            max_length: None,
+            theme,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_clone() {
+        let multi_select = MultiSelectPlus::<String, String>::new().with_prompt("Select your favorite(s)");
+
+        let _ = multi_select.clone();
+    }
+}

--- a/src/prompts/multi_select_plus.rs
+++ b/src/prompts/multi_select_plus.rs
@@ -111,6 +111,10 @@ impl <'a> MultiSelectPlus<'a> {
     }
 }
 
+/// A callback that can be used to modify the items in the multi select prompt.
+/// Executed between the selection of an item and the rendering of the prompt.
+/// * `item` - The item that was selected
+/// * `items` - The current list of items
 pub type SelectCallback<'a> = dyn Fn(&MultiSelectPlusItem, &Vec<MultiSelectPlusItem>) -> Option<Vec<MultiSelectPlusItem>> + 'a;
 
 
@@ -270,13 +274,12 @@ impl<'a> MultiSelectPlus<'a> {
         let size_vec = self
             .items
             .iter()
-            .flat_map(|i| {
-                i.name
-                    .to_string()
+            .flat_map(|i|
+                i.summary_text
                     .split('\n')
                     .map(|s| s.len())
                     .collect::<Vec<_>>()
-            })
+            )
             .collect::<Vec<_>>();
 
         term.hide_cursor()?;
@@ -400,7 +403,7 @@ impl<'a> MultiSelectPlus<'a> {
                             .into_iter()
                             .enumerate()
                             .filter_map(
-                                |(idx, item)| if item.status.checked { Some(idx) } else { None },
+                                |(idx, item)| if item.status.checked { Some(idx) } else { None }
                             )
                             .collect(),
                     ));
@@ -425,11 +428,31 @@ impl<'a> MultiSelectPlus<'a> {
     /// ## Example
     ///
     /// ```rust,no_run
-    /// use dialoguer::{theme::ColorfulTheme, MultiSelect};
+    /// use dialoguer::{theme::ColorfulTheme, MultiSelectPlus, MultiSelectPlusItem, MultiSelectPlusStatus};
     ///
     /// fn main() {
-    ///     let selection = MultiSelect::with_theme(&ColorfulTheme::default())
-    ///         .items(&["foo", "bar", "baz"])
+    ///     let items = vec![
+    ///         MultiSelectPlusItem {
+    ///             name: String::from("Foo"),
+    ///             summary_text: String::from("Foo"),
+    ///             status: MultiSelectPlusStatus::UNCHECKED
+    ///         },
+    ///         MultiSelectPlusItem {
+    ///             name: String::from("Bar (more details here)"),
+    ///             summary_text: String::from("Bar"),
+    ///             status: MultiSelectPlusStatus::CHECKED
+    ///         },
+    ///         MultiSelectPlusItem {
+    ///             name: String::from("Baz"),
+    ///             summary_text: String::from("Baz"),
+    ///             status: MultiSelectPlusStatus {
+    ///                 checked: false,
+    ///                 symbol: "-"
+    ///             }
+    ///         }
+    ///     ];
+    ///     let selection = MultiSelectPlus::with_theme(&ColorfulTheme::default())
+    ///         .items(items)
     ///         .interact()
     ///         .unwrap();
     /// }

--- a/src/prompts/multi_select_plus.rs
+++ b/src/prompts/multi_select_plus.rs
@@ -151,7 +151,10 @@ impl<'a> MultiSelectPlus<'a> {
     }
 
     /// Adds multiple items to the selector.
-    pub fn items(mut self, items: Vec<MultiSelectPlusItem>) -> Self {
+    pub fn items<I>(mut self, items: I) -> Self
+    where
+        I: IntoIterator<Item = MultiSelectPlusItem>
+    {
         self.items.extend(items);
         self
     }

--- a/src/theme/colorful.rs
+++ b/src/theme/colorful.rs
@@ -1,5 +1,6 @@
 use std::fmt;
 
+use crate::MultiSelectPlusItem;
 use console::{style, Style, StyledObject};
 #[cfg(feature = "fuzzy-select")]
 use fuzzy_matcher::{skim::SkimMatcherV2, FuzzyMatcher};
@@ -315,6 +316,35 @@ impl Theme for ColorfulTheme {
             (false, false) => (
                 &self.unchecked_item_prefix,
                 self.inactive_item_style.apply_to(text),
+            ),
+        };
+
+        write!(f, "{} {}", details.0, details.1)
+    }
+
+    /// Formats a multi select plus prompt item.
+    fn format_multi_select_plus_prompt_item(
+        &self,
+        f: &mut dyn fmt::Write,
+        item: &MultiSelectPlusItem,
+        active: bool,
+    ) -> fmt::Result {
+        let details = match (item.status.checked, active) {
+            (true, true) => (
+                &self.checked_item_prefix,
+                self.active_item_style.apply_to(item.name()),
+            ),
+            (true, false) => (
+                &self.checked_item_prefix,
+                self.inactive_item_style.apply_to(item.name()),
+            ),
+            (false, true) => (
+                &self.unchecked_item_prefix,
+                self.active_item_style.apply_to(item.name()),
+            ),
+            (false, false) => (
+                &self.unchecked_item_prefix,
+                self.inactive_item_style.apply_to(item.name()),
             ),
         };
 

--- a/src/theme/mod.rs
+++ b/src/theme/mod.rs
@@ -6,12 +6,14 @@ use console::style;
 #[cfg(feature = "fuzzy-select")]
 use fuzzy_matcher::{skim::SkimMatcherV2, FuzzyMatcher};
 
+pub use colorful::ColorfulTheme;
+pub use simple::SimpleTheme;
+
+use crate::MultiSelectPlusItem;
+
 mod colorful;
 pub(crate) mod render;
 mod simple;
-
-pub use colorful::ColorfulTheme;
-pub use simple::SimpleTheme;
 
 /// Implements a theme for dialoguer.
 pub trait Theme {
@@ -193,6 +195,23 @@ pub trait Theme {
                 (false, false) => "  [ ]",
             },
             text
+        )
+    }
+
+    fn format_multi_select_plus_prompt_item(
+        &self,
+        f: &mut dyn fmt::Write,
+        item: &MultiSelectPlusItem,
+        active: bool,
+    ) -> fmt::Result {
+        write!(
+            f,
+            "{} {}",
+            match active {
+                true => format!("> [{}]", item.status.symbol),
+                false => format!("  [{}]", item.status.symbol),
+            },
+            item.name
         )
     }
 

--- a/src/theme/render.rs
+++ b/src/theme/render.rs
@@ -4,7 +4,7 @@ use console::{measure_text_width, Term};
 #[cfg(feature = "fuzzy-select")]
 use fuzzy_matcher::skim::SkimMatcherV2;
 
-use crate::{theme::Theme, Result};
+use crate::{theme::Theme, MultiSelectPlusItem, Result};
 
 /// Helper struct to conveniently render a theme.
 pub(crate) struct TermThemeRenderer<'a> {
@@ -207,6 +207,17 @@ impl<'a> TermThemeRenderer<'a> {
         self.write_formatted_line(|this, buf| {
             this.theme
                 .format_multi_select_prompt_item(buf, text, checked, active)
+        })
+    }
+
+    pub fn multi_select_plus_prompt_item(
+        &mut self,
+        item: &MultiSelectPlusItem,
+        active: bool,
+    ) -> Result {
+        self.write_formatted_line(|this, buf| {
+            this.theme
+                .format_multi_select_plus_prompt_item(buf, item, active)
         })
     }
 


### PR DESCRIPTION
This PR introduces a new prompt: `MultiSelectPlus`.

This prompt extends on the existing `MultiSelectPlus`, adding support for:
- custom "checked" states
- separate display text and item name
- callbacks

This allows prompts like this:
[![asciicast showcasing new features](https://asciinema.org/a/S8vwVMBy5pEiImCtuZKcOQc9v.svg)](https://asciinema.org/a/S8vwVMBy5pEiImCtuZKcOQc9v)

I created this feature specifically for https://github.com/SuperCuber/dotter/pull/112. Therefore, it is slightly opinionated. I'd happily alter specifics of the implementation to align the new features with the rest of the library.

Note for reviewers: since I copy-pasted the `multi_select.rs` file, here's the diff between the two:
https://xgob.in/6p6sdiy1
(unfortunately, github doesn't allow you to upload `.diff` or `.patch` files..)