### PR TITLE
fix(input): remove double-width characters correctly

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,7 @@ zeroize = { version = "1.1.1", optional = true }
 fuzzy-matcher = { version = "0.3.7", optional = true }
 shell-words = "1.1.0"
 thiserror = "1.0.40"
+unicode-width = "0.2.0"
 
 [[example]]
 name = "password"

--- a/src/prompts/input.rs
+++ b/src/prompts/input.rs
@@ -6,6 +6,7 @@ use std::{
 };
 
 use console::{Key, Term};
+use unicode_width::UnicodeWidthChar;
 
 #[cfg(feature = "completion")]
 use crate::completion::Completion;
@@ -328,7 +329,7 @@ where
                 match term.read_key()? {
                     Key::Backspace if position > 0 => {
                         position -= 1;
-                        chars.remove(position);
+                        let remove_char = chars.remove(position);
                         let line_size = term.size().1 as usize;
                         // Case we want to delete last char of a line so the cursor is at the beginning of the next line
                         if (position + prompt_len) % (line_size - 1) == 0 {
@@ -336,7 +337,7 @@ where
                             term.move_cursor_up(1)?;
                             term.move_cursor_right(line_size + 1)?;
                         } else {
-                            term.clear_chars(1)?;
+                            term.clear_chars(remove_char.width().unwrap_or_default())?;
                         }
 
                         let tail: String = chars[position..].iter().collect();


### PR DESCRIPTION
Some characters are wide characters (such as Chinese), so when using the backspace key to delete characters, the width of the character should be taken into account for proper backward movement.

before: To remove a Chinese character, you need to press the backspace key twice.

https://github.com/user-attachments/assets/fff67128-5ca3-47a6-965c-06b5cbc7a3e6

after:

https://github.com/user-attachments/assets/1e4fbc50-562b-4e70-a224-c43f337c6677

