### PR TITLE
Detect other keys in Select

### DIFF
--- a/examples/select.rs
+++ b/examples/select.rs
@@ -39,4 +39,23 @@ fn main() {
         .unwrap();
 
     println!("Enjoy your {}!", selections[selection]);
+
+    let keys = vec![console::Key::Char('q'),console::Key::Char('s')];
+
+    let selection_with_keys = Select::with_theme(&ColorfulTheme::default())
+        .with_prompt("Pick your flavor (press q or s to skip)")
+        .default(0)
+        .items(&selections[..])
+        .interact_opt_with_keys(&keys)
+            .unwrap();
+    
+    if let Some(index) = selection_with_keys.index {
+        println!("Enjoy your {}!", selections[index]);
+    }
+    if let Some(key) = selection_with_keys.key {
+        println!("You skippng by pressing {:?}!", key);
+    }
+
+
+    
 }


### PR DESCRIPTION
I had a use case where I wanted to detect additional keystrokes while selecting items in Select. For example, I want to detect if the user press 's' to Skip to the next option.

So I added a new function to select called `interact_opt_with_keys`, where you can supply a `vec` of Key for the select to return back if detected.  The return is a `SelectResult` object, which contains 2 fields:  index which will have the index selected or None, and key which has which optional key was detected or None.

The keys supplied will override any of the existing keystrokes detected.

The return values for all the other interact functions remain the same.

I updated the select.rs example file to demonstrate this function.