### PR TITLE
refactor: replace `thiserror` with a manual impl

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,6 @@ tempfile = { version = "3", optional = true }
 zeroize = { version = "1.1.1", optional = true }
 fuzzy-matcher = { version = "0.3.7", optional = true }
 shell-words = "1.1.0"
-thiserror = "1.0.40"
 
 [[example]]
 name = "password"

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,13 +1,26 @@
-use std::{io::Error as IoError, result::Result as StdResult};
-
-use thiserror::Error;
+use std::{fmt, io::Error as IoError, result::Result as StdResult};
 
 /// Possible errors returned by prompts.
-#[derive(Error, Debug)]
+#[derive(Debug)]
 pub enum Error {
     /// Error while executing IO operations.
-    #[error("IO error: {0}")]
-    IO(#[from] IoError),
+    IO(IoError),
+}
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::IO(io) => write!(f, "IO error: {}", io),
+        }
+    }
+}
+
+impl std::error::Error for Error {}
+
+impl From<IoError> for Error {
+    fn from(err: IoError) -> Self {
+        Self::IO(err)
+    }
 }
 
 /// Result type where errors are of type [Error](enum@Error).


### PR DESCRIPTION
Supercedes #318 as there's no need to update `thiserror` if it's no longer used :grin:

It was easy enough to match the functionality provided by `thiserror` with a manual implementation instead