### PR TITLE
Update console to 0.16

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ password = ["zeroize"]
 completion = []
 
 [dependencies]
-console = "0.15.0"
+console = "0.16.0"
 tempfile = { version = "3", optional = true }
 zeroize = { version = "1.1.1", optional = true }
 fuzzy-matcher = { version = "0.3.7", optional = true }


### PR DESCRIPTION
Fixes #328.

Tested with `cargo test -F history`.